### PR TITLE
Removed the line, so that the grouping will be applied to the query t…

### DIFF
--- a/inc/query-manipulation.php
+++ b/inc/query-manipulation.php
@@ -88,7 +88,6 @@ class QueryManipulation {
 			$join .= "LEFT JOIN ".Table\tablename()." ON ({$wpdb->posts}.ID = ".Table\tablename().".post_id)";
 			$this->isGroupingNeeded = true;
 		}
-		$this->isGroupingNeeded = false;
 
 		return $join;
 	}


### PR DESCRIPTION
Sometimes posts appear more then one time on the authors page, because the grouping is disabled right after being enabled in the query-manipulation.php on line 91.